### PR TITLE
Added edge drawing and window resize functionality

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -15,5 +15,6 @@ const int WINDOW_HEIGHT = 1080;
 // Opaque colors
 const Color BLACK = {0, 0, 0, 255};
 const Color WHITE = {255, 255, 255, 255};
+const Color RED = {255, 0, 0, 255};
 
 #endif

--- a/src/point.h
+++ b/src/point.h
@@ -3,48 +3,9 @@
 
 struct Point
 {
-    float x; // + right
-    float y; // + down
-    float z; // + towards the screen
+    int x; // + right
+    int y; // + down
+    int z; // + towards the screen
 };
-
-// // class defining a triangular surface
-// class Surface
-// {
-// private:
-//     Point p1;
-//     Point p2;
-//     Point p3;
-
-// public:
-//     Surface(); // default constructor (initializes object to default state with no arguments)
-//     Surface(const Point &_p1, const Point &_p2, const Point &_p3);
-//     Surface(const Surface &);            // copy constructor
-//     ~Surface();                          // destructor
-//     Surface &operator=(const Surface &); // copy/assignment operator
-// };
-
-// // implementation
-// Surface::Surface() : p1({-1.0f, -1.0f, 0.0f}), p2(-1.0f, -1.0f, 0.0f), p3(-1.0f, -1.0f, 0.0f) {}
-// Surface::Surface(const Point &_p1, const Point &_p2, const Point &_p3) : p1(_p1), p2(_p2), p3(_p3) {}
-// Surface::Surface(const Surface &s)
-// {
-//     p1 = s.p1;
-//     p2 = s.p2;
-//     p3 = s.p3;
-// }
-
-// Surface::~Surface() {}
-
-// Surface &Surface::operator=(const Surface &s)
-// {
-//     if (this != &s)
-//     {
-//         p1 = s.p1;
-//         p2 = s.p2;
-//         p3 = s.p3;
-//     }
-//     return *this;
-// }
 
 #endif

--- a/src/raster_engine.cpp
+++ b/src/raster_engine.cpp
@@ -1,6 +1,6 @@
 #include <SDL3/SDL.h>
 #include "constants.h"
-#include "point.h"
+#include "surface.hpp"
 
 int main(int argc, char *argv[])
 {
@@ -16,7 +16,8 @@ int main(int argc, char *argv[])
     }
 
     // Create a window and renderer
-    if (!(SDL_CreateWindowAndRenderer("Raster Engine", WINDOW_WIDTH, WINDOW_HEIGHT, 0, &window, &renderer)))
+    SDL_WindowFlags window_flags = (SDL_WindowFlags)(SDL_WINDOW_RESIZABLE);
+    if (!(SDL_CreateWindowAndRenderer("Raster Engine", WINDOW_WIDTH, WINDOW_HEIGHT, window_flags, &window, &renderer)))
     {
         SDL_Log("Could not create window and renderer: %s", SDL_GetError());
         SDL_Quit();
@@ -24,6 +25,8 @@ int main(int argc, char *argv[])
     }
 
     bool quit = false;
+    float width_scale{1.0};
+    float height_scale{1.0};
     SDL_Event event;
 
     // Main game loop
@@ -35,6 +38,11 @@ int main(int argc, char *argv[])
             {
                 quit = true;
             }
+            else if (event.type == SDL_EVENT_WINDOW_RESIZED)
+            {
+                width_scale = static_cast<float>(event.window.data1) / WINDOW_WIDTH;
+                height_scale = static_cast<float>(event.window.data2) / WINDOW_HEIGHT;
+            }
         }
 
         // Black background
@@ -43,13 +51,11 @@ int main(int argc, char *argv[])
         SDL_RenderClear(renderer);
 
         // White dots
-        Point p1{500.0, 300.0, 0.0};
-        Point p2{500.0, 800.0, 0.0};
-        Point p3{1000.0, 800.0, 0.0};
-        SDL_SetRenderDrawColor(renderer, WHITE.r, WHITE.g, WHITE.b, WHITE.a);
-        SDL_RenderPoint(renderer, p1.x, p1.y);
-        SDL_RenderPoint(renderer, p2.x, p2.y);
-        SDL_RenderPoint(renderer, p3.x, p3.y);
+        Surface s1{Point{int(500 * width_scale), int(300 * height_scale), 0},
+                   Point{int(500 * width_scale), int(800 * height_scale), 0},
+                   Point{int(1000 * width_scale), int(800 * height_scale), 0}};
+        s1.draw_vertices(*renderer, WHITE);
+        s1.draw_edges(*renderer, RED);
 
         // Update the screen
         SDL_RenderPresent(renderer);

--- a/src/surface.hpp
+++ b/src/surface.hpp
@@ -1,0 +1,221 @@
+#ifndef SURFACE_HPP
+#define SURFACE_HPP
+
+#include <vector>
+#include <cstdlib>
+#include "constants.h"
+#include "point.h"
+
+using std::abs;
+using std::max;
+using std::min;
+using std::vector;
+
+// class defining a triangular surface
+class Surface
+{
+private:
+    Point p0;
+    Point p1;
+    Point p2;
+
+public:
+    Surface(); // default constructor (initializes object to default state with no arguments)
+    Surface(const Point &_p0, const Point &_p1, const Point &_p2);
+    Surface(const Surface &);            // copy constructor
+    ~Surface();                          // destructor
+    Surface &operator=(const Surface &); // copy/assignment operator
+    void draw_vertices(SDL_Renderer &renderer, const Color &color);
+    vector<Point> get_edge(const Point &pa, const Point &pb);
+    void line_low(const int &x0, const int &y0, const int &x1, const int &y1, vector<Point> &edge_a_b);
+    void line_high(const int &x0, const int &y0, const int &x1, const int &y1, vector<Point> &edge_a_b);
+    void draw_edges(SDL_Renderer &renderer, const Color &color);
+};
+
+// implementation
+Surface::Surface() : p0({-1, -1, -1}), p1({-1, -1, -1}), p2({-1, -1, -1}) {}
+Surface::Surface(const Point &_p0, const Point &_p1, const Point &_p2) : p0(_p0), p1(_p1), p2(_p2) {}
+Surface::Surface(const Surface &s)
+{
+    p0 = s.p0;
+    p1 = s.p1;
+    p2 = s.p2;
+}
+
+Surface::~Surface() {}
+
+Surface &Surface::operator=(const Surface &s)
+{
+    if (this != &s)
+    {
+        p0 = s.p0;
+        p1 = s.p1;
+        p2 = s.p2;
+    }
+    return *this;
+}
+
+void Surface::draw_vertices(SDL_Renderer &renderer, const Color &color)
+{
+    SDL_SetRenderDrawColor(&renderer, color.r, color.g, color.b, color.a);
+    SDL_RenderPoint(&renderer, static_cast<float>(p0.x), static_cast<float>(p0.y));
+    SDL_RenderPoint(&renderer, static_cast<float>(p1.x), static_cast<float>(p1.y));
+    SDL_RenderPoint(&renderer, static_cast<float>(p2.x), static_cast<float>(p2.y));
+}
+
+vector<Point> Surface::get_edge(const Point &pa, const Point &pb)
+{
+    vector<Point> edge_a_b;
+    // case where points have same x coordinate (infinite slope)
+    if (pa.x == pb.x)
+    {
+        // find start and end (not inclusive of edges)
+        int start{min(pa.y, pb.y)};
+        int end{max(pa.y, pb.y)};
+        size_t count = end - start - 1;
+        edge_a_b.reserve(edge_a_b.size() + count);
+
+        for (int i{start + 1}; i < end; ++i)
+        {
+            Point p{pa.x, i, 0};
+            edge_a_b.push_back(p);
+        }
+    }
+    // case where points have same y coordinate (0 slope)
+    else if (pa.y == pb.y)
+    {
+        // find start and end (not inclusive of edges)
+        int start{min(pa.x, pb.x)};
+        int end{max(pa.x, pb.x)};
+        size_t count = end - start - 1;
+        edge_a_b.reserve(edge_a_b.size() + count);
+
+        for (int j{start + 1}; j < end; ++j)
+        {
+            Point p{j, pa.y, 0};
+            edge_a_b.push_back(p);
+        }
+    }
+    // otherwise draw diagonal using Bresenham's algorithm
+    else if (abs(pb.y - pa.y) < abs(pb.x - pa.x))
+        if (pa.x > pb.x)
+            line_low(pb.x, pb.y, pa.x, pa.y, edge_a_b);
+        else
+            line_low(pa.x, pa.y, pb.x, pb.y, edge_a_b);
+    else
+    {
+        if (pa.y > pb.y)
+            line_high(pb.x, pb.y, pa.x, pa.y, edge_a_b);
+        else
+            line_high(pa.x, pa.y, pb.x, pb.y, edge_a_b);
+    }
+
+    return edge_a_b;
+}
+
+// Bresenham's algorithm for slopes with magnitude less than 1
+void Surface::line_low(const int &x0, const int &y0, const int &x1, const int &y1, vector<Point> &edge_a_b)
+{
+    size_t count = x1 - x0 + 1;
+    edge_a_b.reserve(edge_a_b.size() + count);
+
+    int dx{x1 - x0};
+    int dy{y1 - y0};
+
+    int yi = 1;
+    if (dy < 0)
+    {
+        yi = -1;
+        dy = -dy;
+    }
+
+    int D{(2 * dy) - dx};
+    int y{y0};
+
+    for (int x{x0}; x <= x1; ++x)
+    {
+        if (D > 0)
+        {
+            y = y + yi;
+            D = D + (2 * (dy - dx));
+        }
+        else
+        {
+            D = D + 2 * dy;
+        }
+        if (((x == x0) && (y == y0)) || ((x == x1) && (y >= y1)))
+        {
+            continue; // don't overwrite vertices
+        }
+        else
+        {
+            Point p{x, y, 0};
+            edge_a_b.push_back(p);
+        }
+    }
+}
+
+// Bresenham's algorithm for slopes with magnitude greater than or equal to 1
+void Surface::line_high(const int &x0, const int &y0, const int &x1, const int &y1, vector<Point> &edge_a_b)
+{
+    size_t count = y1 - y0 + 1;
+    edge_a_b.reserve(edge_a_b.size() + count);
+
+    int dx{x1 - x0};
+    int dy{y1 - y0};
+
+    int xi = 1;
+    if (dx < 0)
+    {
+        xi = -1;
+        dx = -dx;
+    }
+
+    int D{(2 * dx) - dy};
+    int x{x0};
+
+    for (int y{y0}; y <= y1; ++y)
+    {
+        if (D > 0)
+        {
+            x = x + xi;
+            D = D + (2 * (dx - dy));
+        }
+        else
+        {
+            D = D + 2 * dx;
+        }
+        if (((x == x0) && (y == y0)) || ((x >= x1) && (y == y1)))
+        {
+            continue; // don't overwrite vertices
+        }
+        else
+        {
+            Point p{x, y, 0};
+            edge_a_b.push_back(p);
+        }
+    }
+}
+
+void Surface::draw_edges(SDL_Renderer &renderer, const Color &color)
+{
+    SDL_SetRenderDrawColor(&renderer, color.r, color.g, color.b, color.a);
+
+    vector<Point> edge_0_1 = get_edge(p0, p1);
+    vector<Point> edge_1_2 = get_edge(p1, p2);
+    vector<Point> edge_2_0 = get_edge(p2, p0);
+    for (Point &p : edge_0_1)
+    {
+        SDL_RenderPoint(&renderer, static_cast<float>(p.x), static_cast<float>(p.y));
+    }
+    for (Point &p : edge_1_2)
+    {
+        SDL_RenderPoint(&renderer, static_cast<float>(p.x), static_cast<float>(p.y));
+    }
+    for (Point &p : edge_2_0)
+    {
+        SDL_RenderPoint(&renderer, static_cast<float>(p.x), static_cast<float>(p.y));
+    }
+}
+
+#endif


### PR DESCRIPTION
Created a Surface class, which allows for the definition of a triangular surface with 3 points. Its methods include vertex drawing, and a new edge drawing feature which calculates the appropriate pixels to draw the edge based on Bresenham's line algorithm. 

The window is now resizable, either dragging to resize, or maximizing the window. This dynamically affects the appearance of the output triangle, which will stretch to the new aspect ratio.

<img width="1924" height="1140" alt="09-29-25_1800" src="https://github.com/user-attachments/assets/2fba9f00-90b3-4893-92c3-50760a9728b1" />
