### PR TITLE
Added perspective projection and object movement

### DIFF
--- a/src/camera.hpp
+++ b/src/camera.hpp
@@ -1,0 +1,68 @@
+#ifndef CAMERA_HPP
+#define CAMERA_HPP
+
+#include <numbers>
+#include <cmath>
+#include <cstdlib>
+#include <array>
+#include "constants.h"
+#include "point.h"
+
+using std::abs;
+using std::array;
+using std::tan;
+using std::numbers::pi;
+
+// class defining camera perspective
+class Camera
+{
+private:
+    float f;   // far clipping plane
+    float n;   // near clipping plane
+    float fov; // field of view in degrees
+
+public:
+    Camera(); // default constructor (initializes object to default state with no arguments)
+    Camera(const float &_n, const float &_f, const float &_fov);
+    Camera(const Camera &);            // copy constructor
+    ~Camera();                         // destructor
+    Camera &operator=(const Camera &); // copy/assignment operator
+    array<array<float, 4>, 4> get_projection_matrix();
+};
+
+// implementation
+Camera::Camera() : n(0.1f), f(100.0f), fov(90.0f) {}
+Camera::Camera(const float &_n, const float &_f, const float &_fov)
+    : n(_n), f(_f), fov(_fov) {}
+Camera::Camera(const Camera &c)
+{
+    n = c.n;
+    f = c.f;
+    fov = c.fov;
+}
+
+Camera::~Camera() {}
+
+Camera &Camera::operator=(const Camera &c)
+{
+    if (this != &c)
+    {
+        n = c.n;
+        f = c.f;
+        fov = c.fov;
+    }
+    return *this;
+}
+
+array<array<float, 4>, 4> Camera::get_projection_matrix()
+{
+    float S = 1.0f / tan(fov * 0.5f * pi / 180.0f); // scaling factor
+    array<array<float, 4>, 4> projection_matrix = {
+        {{S, 0.0f, 0.0f, 0.0f},
+         {0.0f, S, 0.0f, 0.0f},
+         {0.0f, 0.0f, -f / (f - n), -(f * n) / (f - n)},
+         {0.0f, 0.0f, -1.0f, 0.0f}}};
+    return projection_matrix;
+}
+
+#endif

--- a/src/constants.h
+++ b/src/constants.h
@@ -10,11 +10,16 @@ struct Color
 };
 
 // Window dimensions
-const int WINDOW_WIDTH = 1920;
+const int WINDOW_WIDTH = 1080;
 const int WINDOW_HEIGHT = 1080;
 // Opaque colors
 const Color BLACK = {0, 0, 0, 255};
 const Color WHITE = {255, 255, 255, 255};
 const Color RED = {255, 0, 0, 255};
+const Color BLUE = {0, 0, 255, 255};
+const Color GREEN = {0, 255, 0, 255};
+const Color YELLOW = {255, 255, 0, 255};
+const Color MAGENTA = {255, 0, 255, 255};
+const Color CYAN = {0, 255, 255, 255};
 
 #endif

--- a/src/gridpoint.h
+++ b/src/gridpoint.h
@@ -1,0 +1,11 @@
+#ifndef GRIDPOINT_H
+#define GRIDPOINT_H
+
+struct GridPoint
+{
+    int x;   // + right from top left of window
+    int y;   // + down from top left of window
+    float z; // between 0 and 1 if within view frustum
+};
+
+#endif

--- a/src/point.h
+++ b/src/point.h
@@ -3,9 +3,9 @@
 
 struct Point
 {
-    int x; // + right
-    int y; // + down
-    int z; // + towards the screen
+    float x; // + right
+    float y; // + up
+    float z; // + towards the screen
 };
 
 #endif

--- a/src/rectprism.hpp
+++ b/src/rectprism.hpp
@@ -1,0 +1,133 @@
+#ifndef RECTPRISM_HPP
+#define RECTPRISM_HPP
+
+#include <vector>
+#include <cstdlib>
+#include "point.h"
+#include "surface.hpp"
+#include "constants.h"
+
+using std::vector;
+
+// class defining a triangular RectPrism
+class RectPrism
+{
+private:
+    float center_x;
+    float center_y;
+    float center_z;
+    float width;
+    float height;
+    float depth;
+    vector<Surface> surfaces;
+
+public:
+    RectPrism(); // default constructor (initializes object to default state with no arguments)
+    RectPrism(const float &_x, const float &_y, const float &_z, const float &_w, const float &_h, const float &_d);
+    RectPrism(const RectPrism &);            // copy constructor
+    ~RectPrism();                            // destructor
+    RectPrism &operator=(const RectPrism &); // copy/assignment operator
+    void make_shape();
+    void translate(float dx, float dy, float dz);
+    vector<Surface> &get_surfaces();
+};
+
+// implementation
+RectPrism::RectPrism() : center_x(0), center_y(0), center_z(0), width(1), height(1), depth(1) {}
+RectPrism::RectPrism(const float &_x, const float &_y, const float &_z, const float &_w, const float &_h, const float &_d) : center_x(_x), center_y(_y), center_z(_z), width(_w), height(_h), depth(_d)
+{
+    make_shape();
+}
+RectPrism::RectPrism(const RectPrism &r)
+{
+    center_x = r.center_x;
+    center_y = r.center_y;
+    center_z = r.center_z;
+    width = r.width;
+    height = r.height;
+    depth = r.depth;
+}
+
+RectPrism::~RectPrism() {}
+
+RectPrism &RectPrism::operator=(const RectPrism &r)
+{
+    if (this != &r)
+    {
+        center_x = r.center_x;
+        center_y = r.center_y;
+        center_z = r.center_z;
+        width = r.width;
+        height = r.height;
+        depth = r.depth;
+    }
+    return *this;
+}
+
+void RectPrism::make_shape()
+{
+    Surface front_left(Point{center_x - width / 2, center_y - height / 2, center_z + depth / 2},
+                       Point{center_x - width / 2, center_y + height / 2, center_z + depth / 2},
+                       Point{center_x + width / 2, center_y - height / 2, center_z + depth / 2}, RED);
+    Surface front_right(Point{center_x - width / 2, center_y + height / 2, center_z + depth / 2},
+                        Point{center_x + width / 2, center_y - height / 2, center_z + depth / 2},
+                        Point{center_x + width / 2, center_y + height / 2, center_z + depth / 2}, RED);
+    Surface rear_left(Point{center_x - width / 2, center_y - height / 2, center_z - depth / 2},
+                      Point{center_x - width / 2, center_y + height / 2, center_z - depth / 2},
+                      Point{center_x + width / 2, center_y + height / 2, center_z - depth / 2}, MAGENTA);
+    Surface rear_right(Point{center_x - width / 2, center_y - height / 2, center_z - depth / 2},
+                       Point{center_x + width / 2, center_y - height / 2, center_z - depth / 2},
+                       Point{center_x + width / 2, center_y + height / 2, center_z - depth / 2}, MAGENTA);
+    Surface left_near(Point{center_x - width / 2, center_y - height / 2, center_z + depth / 2},
+                      Point{center_x - width / 2, center_y + height / 2, center_z + depth / 2},
+                      Point{center_x - width / 2, center_y - height / 2, center_z - depth / 2}, BLUE);
+    Surface left_far(Point{center_x - width / 2, center_y - height / 2, center_z - depth / 2},
+                     Point{center_x - width / 2, center_y + height / 2, center_z - depth / 2},
+                     Point{center_x - width / 2, center_y + height / 2, center_z + depth / 2}, BLUE);
+    Surface right_near(Point{center_x + width / 2, center_y - height / 2, center_z + depth / 2},
+                       Point{center_x + width / 2, center_y + height / 2, center_z + depth / 2},
+                       Point{center_x + width / 2, center_y + height / 2, center_z - depth / 2}, CYAN);
+    Surface right_far(Point{center_x + width / 2, center_y - height / 2, center_z - depth / 2},
+                      Point{center_x + width / 2, center_y + height / 2, center_z - depth / 2},
+                      Point{center_x + width / 2, center_y - height / 2, center_z + depth / 2}, CYAN);
+    Surface bottom_near(Point{center_x - width / 2, center_y - height / 2, center_z + depth / 2},
+                        Point{center_x + width / 2, center_y - height / 2, center_z + depth / 2},
+                        Point{center_x + width / 2, center_y - height / 2, center_z - depth / 2}, YELLOW);
+    Surface bottom_far(Point{center_x - width / 2, center_y - height / 2, center_z + depth / 2},
+                       Point{center_x - width / 2, center_y - height / 2, center_z - depth / 2},
+                       Point{center_x + width / 2, center_y - height / 2, center_z - depth / 2}, YELLOW);
+    Surface top_near(Point{center_x - width / 2, center_y + height / 2, center_z + depth / 2},
+                     Point{center_x - width / 2, center_y + height / 2, center_z - depth / 2},
+                     Point{center_x + width / 2, center_y + height / 2, center_z + depth / 2}, GREEN);
+    Surface top_far(Point{center_x - width / 2, center_y + height / 2, center_z - depth / 2},
+                    Point{center_x + width / 2, center_y + height / 2, center_z - depth / 2},
+                    Point{center_x + width / 2, center_y + height / 2, center_z + depth / 2}, GREEN);
+
+    surfaces.push_back(front_left);
+    surfaces.push_back(front_right);
+    surfaces.push_back(rear_left);
+    surfaces.push_back(rear_right);
+    surfaces.push_back(left_near);
+    surfaces.push_back(left_far);
+    surfaces.push_back(right_near);
+    surfaces.push_back(right_far);
+    surfaces.push_back(bottom_near);
+    surfaces.push_back(bottom_far);
+    surfaces.push_back(top_near);
+    surfaces.push_back(top_far);
+}
+
+void RectPrism::translate(float dx, float dy, float dz)
+{
+    for (auto &surface : surfaces)
+    {
+        surface.translate(dx, dy, dz);
+    }
+}
+
+vector<Surface> &RectPrism::get_surfaces()
+{
+    return surfaces;
+}
+
+#endif

--- a/src/surface.hpp
+++ b/src/surface.hpp
@@ -3,43 +3,65 @@
 
 #include <vector>
 #include <cstdlib>
+#include <string>
+#include <array>
 #include "constants.h"
 #include "point.h"
+#include "gridpoint.h"
 
 using std::abs;
+using std::array;
 using std::max;
 using std::min;
+using std::string;
 using std::vector;
 
 // class defining a triangular surface
 class Surface
 {
 private:
-    Point p0;
+    Point p0; // original coordinates
     Point p1;
     Point p2;
+    GridPoint c0; // transformed into camera perspective
+    GridPoint c1;
+    GridPoint c2;
+    Color vertex_color;
+    Color edge_color;
 
 public:
     Surface(); // default constructor (initializes object to default state with no arguments)
-    Surface(const Point &_p0, const Point &_p1, const Point &_p2);
+    Surface(const Point &_p0, const Point &_p1, const Point &_p2,
+            const Color &_edge_color = RED, const Color &_vertex_color = WHITE);
     Surface(const Surface &);            // copy constructor
     ~Surface();                          // destructor
     Surface &operator=(const Surface &); // copy/assignment operator
-    void draw_vertices(SDL_Renderer &renderer, const Color &color);
-    vector<Point> get_edge(const Point &pa, const Point &pb);
-    void line_low(const int &x0, const int &y0, const int &x1, const int &y1, vector<Point> &edge_a_b);
-    void line_high(const int &x0, const int &y0, const int &x1, const int &y1, vector<Point> &edge_a_b);
-    void draw_edges(SDL_Renderer &renderer, const Color &color);
+    void matrix_mult(const array<array<float, 4>, 4> &m, Point &c);
+    void transform_to_camera(const array<array<float, 4>, 4> &m, const int &width, const int &height);
+    GridPoint createGridPointFromPoint(const Point &p, const int &width, const int &height);
+    void draw_vertices(SDL_Renderer &renderer, const int &width, const int &height);
+    vector<GridPoint> get_edge(const GridPoint &ca, const GridPoint &cb);
+    void line_low(const int &x0, const int &y0, const float &z0,
+                  const int &x1, const int &y1, const float &z1, vector<GridPoint> &edge_a_b);
+    void line_high(const int &x0, const int &y0, const float &z0,
+                   const int &x1, const int &y1, const float &z1, vector<GridPoint> &edge_a_b);
+    void draw_edges(SDL_Renderer &renderer, const int &width, const int &height);
+    void set_vertex_color(const Color &color);
+    void set_edge_color(const Color &color);
+    void translate(float dx, float dy, float dz);
 };
 
 // implementation
-Surface::Surface() : p0({-1, -1, -1}), p1({-1, -1, -1}), p2({-1, -1, -1}) {}
-Surface::Surface(const Point &_p0, const Point &_p1, const Point &_p2) : p0(_p0), p1(_p1), p2(_p2) {}
+Surface::Surface() : p0({0.0f, 0.0f, 0.0f}), p1({0.0f, 0.0f, 0.0f}), p2({0.0f, 0.0f, 0.0f}) {}
+Surface::Surface(const Point &_p0, const Point &_p1, const Point &_p2, const Color &_edge_color, const Color &_vertex_color)
+    : p0(_p0), p1(_p1), p2(_p2), edge_color(_edge_color), vertex_color(_vertex_color) {}
 Surface::Surface(const Surface &s)
 {
     p0 = s.p0;
     p1 = s.p1;
     p2 = s.p2;
+    edge_color = s.edge_color;
+    vertex_color = s.vertex_color;
 }
 
 Surface::~Surface() {}
@@ -51,70 +73,120 @@ Surface &Surface::operator=(const Surface &s)
         p0 = s.p0;
         p1 = s.p1;
         p2 = s.p2;
+        edge_color = s.edge_color;
+        vertex_color = s.vertex_color;
     }
     return *this;
 }
 
-void Surface::draw_vertices(SDL_Renderer &renderer, const Color &color)
+void Surface::matrix_mult(const array<array<float, 4>, 4> &m, Point &p)
 {
-    SDL_SetRenderDrawColor(&renderer, color.r, color.g, color.b, color.a);
-    SDL_RenderPoint(&renderer, static_cast<float>(p0.x), static_cast<float>(p0.y));
-    SDL_RenderPoint(&renderer, static_cast<float>(p1.x), static_cast<float>(p1.y));
-    SDL_RenderPoint(&renderer, static_cast<float>(p2.x), static_cast<float>(p2.y));
+    Point orig = p;
+    p.x = orig.x * m[0][0] + orig.y * m[0][1] + orig.z * m[0][2] + m[0][3];
+    p.y = orig.x * m[1][0] + orig.y * m[1][1] + orig.z * m[1][2] + m[1][3];
+    p.z = orig.x * m[2][0] + orig.y * m[2][1] + orig.z * m[2][2] + m[2][3];
+    float w = orig.x * m[3][0] + orig.y * m[3][1] + orig.z * m[3][2] + m[3][3];
+
+    // convert from homogeneous to Cartesian coordinates
+    if (w != 1 && w != 0)
+    {
+        p.x /= w;
+        p.y /= w;
+        p.z /= w;
+    }
 }
 
-vector<Point> Surface::get_edge(const Point &pa, const Point &pb)
+void Surface::transform_to_camera(const array<array<float, 4>, 4> &m, const int &width, const int &height)
 {
-    vector<Point> edge_a_b;
+    Point c0_temp = p0;
+    Point c1_temp = p1;
+    Point c2_temp = p2;
+    matrix_mult(m, c0_temp);
+    matrix_mult(m, c1_temp);
+    matrix_mult(m, c2_temp);
+    c0 = createGridPointFromPoint(c0_temp, width, height);
+    c1 = createGridPointFromPoint(c1_temp, width, height);
+    c2 = createGridPointFromPoint(c2_temp, width, height);
+}
+
+GridPoint Surface::createGridPointFromPoint(const Point &p, const int &width, const int &height)
+{
+    // convert position to screen coordinates
+    int x = static_cast<int>((p.x + 1) * 0.5 * width);
+    int y = static_cast<int>((1 - (p.y + 1) * 0.5) * height);
+
+    GridPoint c{x, y, p.z};
+    return c;
+}
+
+void Surface::draw_vertices(SDL_Renderer &renderer, const int &width, const int &height)
+{
+    SDL_SetRenderDrawColor(&renderer, vertex_color.r, vertex_color.g, vertex_color.b, vertex_color.a);
+    if (c0.x <= width && c0.x >= 0 && c0.y <= height && c0.y >= 0 && c0.z > 0 && c0.z < 1)
+        SDL_RenderPoint(&renderer, static_cast<float>(c0.x), static_cast<float>(c0.y));
+    if (c1.x <= width && c1.x >= 0 && c1.y <= height && c1.y >= 0 && c1.z > 0 && c1.z < 1)
+        SDL_RenderPoint(&renderer, static_cast<float>(c1.x), static_cast<float>(c1.y));
+    if (c2.x <= width && c2.x >= 0 && c2.y <= height && c2.y >= 0 && c2.z > 0 && c2.z < 1)
+        SDL_RenderPoint(&renderer, static_cast<float>(c2.x), static_cast<float>(c2.y));
+}
+
+vector<GridPoint> Surface::get_edge(const GridPoint &ca, const GridPoint &cb)
+{
+    vector<GridPoint> edge_a_b;
     // case where points have same x coordinate (infinite slope)
-    if (pa.x == pb.x)
+    if (ca.x == cb.x)
     {
         // find start and end (not inclusive of edges)
-        int start{min(pa.y, pb.y)};
-        int end{max(pa.y, pb.y)};
+        int start{min(ca.y, cb.y)};
+        int end{max(ca.y, cb.y)};
         size_t count = end - start - 1;
         edge_a_b.reserve(edge_a_b.size() + count);
+        float z;
 
-        for (int i{start + 1}; i < end; ++i)
+        for (int j{start + 1}; j < end; ++j)
         {
-            Point p{pa.x, i, 0};
+            z = (cb.z - ca.z) * (j - ca.y) / (cb.y - ca.y) + ca.z;
+            GridPoint p{ca.x, j, z};
             edge_a_b.push_back(p);
         }
     }
     // case where points have same y coordinate (0 slope)
-    else if (pa.y == pb.y)
+    else if (ca.y == cb.y)
     {
         // find start and end (not inclusive of edges)
-        int start{min(pa.x, pb.x)};
-        int end{max(pa.x, pb.x)};
+        int start{min(ca.x, cb.x)};
+        int end{max(ca.x, cb.x)};
         size_t count = end - start - 1;
         edge_a_b.reserve(edge_a_b.size() + count);
+        float z;
 
-        for (int j{start + 1}; j < end; ++j)
+        for (int i{start + 1}; i < end; ++i)
         {
-            Point p{j, pa.y, 0};
+            z = (cb.z - ca.z) * (i - ca.x) / (cb.x - ca.x) + ca.z;
+            GridPoint p{i, ca.y, z};
             edge_a_b.push_back(p);
         }
     }
     // otherwise draw diagonal using Bresenham's algorithm
-    else if (abs(pb.y - pa.y) < abs(pb.x - pa.x))
-        if (pa.x > pb.x)
-            line_low(pb.x, pb.y, pa.x, pa.y, edge_a_b);
+    else if (abs(cb.y - ca.y) < abs(cb.x - ca.x))
+        if (ca.x > cb.x)
+            line_low(cb.x, cb.y, cb.z, ca.x, ca.y, ca.z, edge_a_b);
         else
-            line_low(pa.x, pa.y, pb.x, pb.y, edge_a_b);
+            line_low(ca.x, ca.y, ca.z, cb.x, cb.y, cb.z, edge_a_b);
     else
     {
-        if (pa.y > pb.y)
-            line_high(pb.x, pb.y, pa.x, pa.y, edge_a_b);
+        if (ca.y > cb.y)
+            line_high(cb.x, cb.y, cb.z, ca.x, ca.y, ca.z, edge_a_b);
         else
-            line_high(pa.x, pa.y, pb.x, pb.y, edge_a_b);
+            line_high(ca.x, ca.y, ca.z, cb.x, cb.y, cb.z, edge_a_b);
     }
 
     return edge_a_b;
 }
 
 // Bresenham's algorithm for slopes with magnitude less than 1
-void Surface::line_low(const int &x0, const int &y0, const int &x1, const int &y1, vector<Point> &edge_a_b)
+void Surface::line_low(const int &x0, const int &y0, const float &z0,
+                       const int &x1, const int &y1, const float &z1, vector<GridPoint> &edge_a_b)
 {
     size_t count = x1 - x0 + 1;
     edge_a_b.reserve(edge_a_b.size() + count);
@@ -131,6 +203,7 @@ void Surface::line_low(const int &x0, const int &y0, const int &x1, const int &y
 
     int D{(2 * dy) - dx};
     int y{y0};
+    float z;
 
     for (int x{x0}; x <= x1; ++x)
     {
@@ -149,14 +222,16 @@ void Surface::line_low(const int &x0, const int &y0, const int &x1, const int &y
         }
         else
         {
-            Point p{x, y, 0};
+            z = (z1 - z0) * (x - x0) / (x1 - x0) + z0;
+            GridPoint p{x, y, z};
             edge_a_b.push_back(p);
         }
     }
 }
 
 // Bresenham's algorithm for slopes with magnitude greater than or equal to 1
-void Surface::line_high(const int &x0, const int &y0, const int &x1, const int &y1, vector<Point> &edge_a_b)
+void Surface::line_high(const int &x0, const int &y0, const float &z0,
+                        const int &x1, const int &y1, const float &z1, vector<GridPoint> &edge_a_b)
 {
     size_t count = y1 - y0 + 1;
     edge_a_b.reserve(edge_a_b.size() + count);
@@ -173,6 +248,7 @@ void Surface::line_high(const int &x0, const int &y0, const int &x1, const int &
 
     int D{(2 * dx) - dy};
     int x{x0};
+    float z;
 
     for (int y{y0}; y <= y1; ++y)
     {
@@ -191,31 +267,60 @@ void Surface::line_high(const int &x0, const int &y0, const int &x1, const int &
         }
         else
         {
-            Point p{x, y, 0};
+            z = (z1 - z0) * (y - y0) / (y1 - y0) + z0;
+            GridPoint p{x, y, z};
             edge_a_b.push_back(p);
         }
     }
 }
 
-void Surface::draw_edges(SDL_Renderer &renderer, const Color &color)
+void Surface::draw_edges(SDL_Renderer &renderer, const int &width, const int &height)
 {
-    SDL_SetRenderDrawColor(&renderer, color.r, color.g, color.b, color.a);
+    SDL_SetRenderDrawColor(&renderer, edge_color.r, edge_color.g, edge_color.b, edge_color.a);
 
-    vector<Point> edge_0_1 = get_edge(p0, p1);
-    vector<Point> edge_1_2 = get_edge(p1, p2);
-    vector<Point> edge_2_0 = get_edge(p2, p0);
-    for (Point &p : edge_0_1)
+    vector<GridPoint> edge_0_1 = get_edge(c0, c1);
+    vector<GridPoint> edge_1_2 = get_edge(c1, c2);
+    vector<GridPoint> edge_2_0 = get_edge(c2, c0);
+    for (GridPoint &c : edge_0_1)
     {
-        SDL_RenderPoint(&renderer, static_cast<float>(p.x), static_cast<float>(p.y));
+        if (c.x <= width && c.x >= 0 && c.y <= height && c.y >= 0 && c.z > 0 && c.z < 1)
+            SDL_RenderPoint(&renderer, static_cast<float>(c.x), static_cast<float>(c.y));
     }
-    for (Point &p : edge_1_2)
+    for (GridPoint &c : edge_1_2)
     {
-        SDL_RenderPoint(&renderer, static_cast<float>(p.x), static_cast<float>(p.y));
+        if (c.x <= width && c.x >= 0 && c.y <= height && c.y >= 0 && c.z > 0 && c.z < 1)
+            SDL_RenderPoint(&renderer, static_cast<float>(c.x), static_cast<float>(c.y));
     }
-    for (Point &p : edge_2_0)
+    for (GridPoint &c : edge_2_0)
     {
-        SDL_RenderPoint(&renderer, static_cast<float>(p.x), static_cast<float>(p.y));
+        if (c.x <= width && c.x >= 0 && c.y <= height && c.y >= 0 && c.z > 0 && c.z < 1)
+            SDL_RenderPoint(&renderer, static_cast<float>(c.x), static_cast<float>(c.y));
     }
+}
+
+void Surface::set_vertex_color(const Color &color)
+{
+    vertex_color = color;
+}
+
+void Surface::set_edge_color(const Color &color)
+{
+    edge_color = color;
+}
+
+void Surface::translate(float dx, float dy, float dz)
+{
+    p0.x += dx;
+    p0.y += dy;
+    p0.z += dz;
+
+    p1.x += dx;
+    p1.y += dy;
+    p1.z += dz;
+
+    p2.x += dx;
+    p2.y += dy;
+    p2.z += dz;
 }
 
 #endif


### PR DESCRIPTION
Surfaces are now drawn using perspective projection, based on a right-hand projection matrix (coordinates +x right, +y up, +z out of page) with a specified field of view, near clipping plane distance, and far clipping plane distance. This required a new class representing a Camera and a GridPoint structure, where the camera is aligned with the -z axis, pointing into the page. Transformed coordinates fall into a range of [0, 1] if they are within the viewing frustum, where x and y values are scaled up based on the screen dimensions.

Created a RectPrism class to represent a rectangular prism, consisting of 12 triangular surfaces. Modified the surface class to store color values for the edges and vertices, and specified hard-coded colors for the prism's sides for visualization.

Implemented basic shape movement using the W, A, S, D, Q, and E keys. Note that the camera is fixed in this implementation.

Currently, clipping into the near plane can crash the program since the allocated GridPoint vectors for edge drawing are too large in size.

<img width="1084" height="1140" alt="10-01-25_1115" src="https://github.com/user-attachments/assets/d79be8a5-6659-4595-aced-f0c273826e08" />
