### PR TITLE
Added map class, two shape classes, and diminished lighting

### DIFF
--- a/src/constants.h
+++ b/src/constants.h
@@ -12,19 +12,33 @@ struct Color
 // Window dimensions
 
 // Default renderer options
-const int WIDTH = 1080;
-const int HEIGHT = 1080;
-const float PLANE_N = 0.1f;   // near clipping plane
-const float PLANE_F = 100.0f; // far clipping plane
-const float FOV = 90.0f;      // field of view in degrees
+const int WIDTH{640};
+const int HEIGHT{480};
+const float PLANE_N{0.3f};   // near clipping plane
+const float PLANE_F{100.0f}; // far clipping plane
+const float FOV{90.0f};      // field of view in degrees
+// Tolerances for rendering
+const float TOL_IN_TRIANGLE{1e-4};   // tolerance check for coordinate in triangle
+const float TOL_SHIFT_SURFACE{1e-6}; // tolerance used to offset surfaces to avoid z-fighting
+// Diminished lighting options
+const float Z_BRIGHT = 0.95;
+const float Z_DARK = 0.99;
+const float DARK_FACTOR = 0.75;
 // Opaque colors
 const Color BLACK = {0, 0, 0, 255};
 const Color WHITE = {255, 255, 255, 255};
 const Color RED = {255, 0, 0, 255};
 const Color BLUE = {0, 0, 255, 255};
 const Color GREEN = {0, 255, 0, 255};
+const Color MEDGREEN = {0, 180, 0, 255};
+const Color DKGREEN = {0, 100, 0, 255};
 const Color YELLOW = {255, 255, 0, 255};
 const Color MAGENTA = {255, 0, 255, 255};
 const Color CYAN = {0, 255, 255, 255};
+const Color BROWN = {150, 75, 0, 255};
+const Color TAN = {210, 180, 140, 255};
+const Color SKY_BLUE = {135, 206, 235, 255};
+// Background color for screen
+const Color BACK_COLOR = SKY_BLUE;
 
 #endif

--- a/src/input.hpp
+++ b/src/input.hpp
@@ -1,0 +1,44 @@
+#ifndef INPUT_HPP
+#define INPUT_HPP
+
+#include <SDL3/SDL.h>
+#include "rectprism.hpp"
+
+using std::vector;
+
+void process_input(SDL_Event &event, RectPrism &rect, bool &need_redraw)
+{
+    float translate_amount = 0.05f;
+    if (event.key.key == SDLK_A)
+    {
+        rect.translate(-1 * translate_amount, 0.0f, 0.0f);
+        need_redraw = true;
+    }
+    else if (event.key.key == SDLK_D)
+    {
+        rect.translate(translate_amount, 0.0f, 0.0f);
+        need_redraw = true;
+    }
+    else if (event.key.key == SDLK_W)
+    {
+        rect.translate(0.0f, 0.0f, translate_amount);
+        need_redraw = true;
+    }
+    else if (event.key.key == SDLK_S)
+    {
+        rect.translate(0.0f, 0.0f, -1 * translate_amount);
+        need_redraw = true;
+    }
+    else if (event.key.key == SDLK_Q)
+    {
+        rect.translate(0.0f, translate_amount, 0.0f);
+        need_redraw = true;
+    }
+    else if (event.key.key == SDLK_E)
+    {
+        rect.translate(0.0f, -1 * translate_amount, 0.0f);
+        need_redraw = true;
+    }
+}
+
+#endif

--- a/src/map.hpp
+++ b/src/map.hpp
@@ -1,0 +1,117 @@
+#ifndef MAP_HPP
+#define MAP_HPP
+
+#include <vector>
+#include <string>
+#include "surface.hpp"
+#include "rectprism.hpp"
+#include "rect.hpp"
+#include "pyramid.hpp"
+
+using std::string;
+using std::vector;
+
+// class defining Renderer perspective
+class Map
+{
+private:
+    vector<RectPrism> shapes_rect_prism;
+    vector<Pyramid> shapes_pyramid;
+    vector<Rect> shapes_rect;
+    vector<Surface> shapes_triangle;
+    vector<Surface> all_surfaces;
+
+public:
+    Map();                                // default constructor (initializes object to default state with no arguments)
+    Map(const Map &) = delete;            // prevent copy
+    ~Map();                               // destructor
+    Map &operator=(const Map &) = delete; // prevent copy/assignment
+    vector<Surface> &get_map_surfaces();
+    void push_surfaces(const vector<Surface> &temp_surfaces);
+    RectPrism &get_rect_prism(const int &index);
+    Pyramid &get_pyramid(const int &index);
+    Rect &get_rect(const int &index);
+    Surface &get_triangle(const int &index);
+};
+
+Map::Map()
+{
+    // right tree
+    shapes_rect_prism.push_back(RectPrism(2.5f, -1.0f, -7.0f, 0.5f, 2.0f, 0.5f, {BROWN, BROWN, TAN, TAN, BROWN, BROWN}));
+    shapes_pyramid.push_back(Pyramid(2.5f, 0.0f, -7.0f, 2.0f, 2.0f, 2.0f, {DKGREEN, DKGREEN, MEDGREEN, MEDGREEN, BLACK}));
+
+    // left tree
+    shapes_rect_prism.push_back(RectPrism(-2.8f, 0.0f, -10.0f, 0.75f, 4.0f, 0.75f, {BROWN, BROWN, TAN, TAN, BROWN, BROWN}));
+    shapes_pyramid.push_back(Pyramid(-2.8f, 2.0f, -10.0f, 3.0f, 3.0f, 3.0f, {DKGREEN, DKGREEN, MEDGREEN, MEDGREEN, BLACK}));
+
+    // grass surface
+    shapes_rect.push_back(Rect(0.0f, -2.0f, -10.0f, 10.0f, 0.0f, 10.0f, GREEN, true));
+
+    // cloud
+    shapes_triangle.push_back(Surface(Point{0.5f, 10.5f, -15.0f, 1.0f}, Point{4.0f, 11.0f, -15.0f, 1.0f}, Point{2.5f, 9.0f, -15.0f, 1.0f}, WHITE));
+    shapes_triangle.push_back(Surface(Point{0.0f, 10.0f, -15.0f, 1.0f}, Point{2.0f, 12.5f, -15.0f, 1.0f}, Point{3.0f, 10.5f, -15.0f, 1.0f}, WHITE));
+    shapes_triangle.push_back(Surface(Point{1.2f, 10.5f, -15.0f, 1.0f}, Point{3.5f, 12.0f, -15.0f, 1.0f}, Point{4.5f, 10.0f, -15.0f, 1.0f}, WHITE));
+}
+
+Map::~Map() {}
+
+vector<Surface> &Map::get_map_surfaces()
+{
+    all_surfaces.clear();
+
+    for (auto &shape : shapes_rect_prism)
+    {
+        push_surfaces(shape.get_surfaces());
+    }
+
+    for (auto &shape : shapes_pyramid)
+    {
+        push_surfaces(shape.get_surfaces());
+    }
+
+    for (auto &shape : shapes_rect)
+    {
+        push_surfaces(shape.get_surfaces());
+    }
+
+    for (auto &shape : shapes_triangle)
+    {
+        all_surfaces.push_back(shape);
+    }
+
+    return all_surfaces;
+}
+
+void Map::push_surfaces(const vector<Surface> &temp_surfaces)
+{
+    for (const auto &surface : temp_surfaces)
+    {
+        all_surfaces.push_back(surface);
+    }
+}
+
+// Return reference to RectPrism object
+RectPrism &Map::get_rect_prism(const int &index)
+{
+    return shapes_rect_prism[index];
+}
+
+// Return reference to Pyramid object
+Pyramid &Map::get_pyramid(const int &index)
+{
+    return shapes_pyramid[index];
+}
+
+// Return reference to Rect object
+Rect &Map::get_rect(const int &index)
+{
+    return shapes_rect[index];
+}
+
+// Return reference to Surface (triangle) object
+Surface &Map::get_triangle(const int &index)
+{
+    return shapes_triangle[index];
+}
+
+#endif

--- a/src/pyramid.hpp
+++ b/src/pyramid.hpp
@@ -1,0 +1,128 @@
+#ifndef PYRAMID_HPP
+#define PYRAMID_HPP
+
+#include <vector>
+#include <cstdlib>
+#include "point.h"
+#include "surface.hpp"
+#include "constants.h"
+
+using std::vector;
+
+// class defining a rectangular prism
+class Pyramid
+{
+private:
+    float center_x;
+    float bottom_y;
+    float center_z;
+    float width;
+    float height;
+    float depth;
+    vector<Color> colors; // front, rear, left, right, bottom
+    vector<Surface> surfaces;
+    bool diminish_light;
+
+public:
+    Pyramid(); // default constructor (initializes object to default state with no arguments)
+    Pyramid(const float &_x, const float &_y, const float &_z, const float &_w, const float &_h, const float &_d,
+            const vector<Color> &_colors, const bool &_dim_light = false);
+    Pyramid(const Pyramid &);            // copy constructor
+    ~Pyramid();                          // destructor
+    Pyramid &operator=(const Pyramid &); // copy/assignment operator
+    void make_shape();
+    void translate(float dx, float dy, float dz);
+    vector<Surface> &get_surfaces();
+};
+
+// implementation
+Pyramid::Pyramid() : center_x(0), bottom_y(0), center_z(0), width(1), height(1), depth(1),
+                     colors({RED, MAGENTA, BLUE, CYAN, YELLOW}), diminish_light(false) {}
+Pyramid::Pyramid(const float &_x, const float &_y, const float &_z, const float &_w, const float &_h, const float &_d,
+                 const vector<Color> &_colors, const bool &_dim_light)
+    : center_x(_x), bottom_y(_y), center_z(_z), width(_w), height(_h), depth(_d), colors(_colors), diminish_light(_dim_light)
+{
+    make_shape();
+}
+Pyramid::Pyramid(const Pyramid &r)
+{
+    center_x = r.center_x;
+    bottom_y = r.bottom_y;
+    center_z = r.center_z;
+    width = r.width;
+    height = r.height;
+    depth = r.depth;
+    colors = r.colors;
+    diminish_light = r.diminish_light;
+    make_shape();
+}
+
+Pyramid::~Pyramid() {}
+
+Pyramid &Pyramid::operator=(const Pyramid &r)
+{
+    if (this != &r)
+    {
+        center_x = r.center_x;
+        bottom_y = r.bottom_y;
+        center_z = r.center_z;
+        width = r.width;
+        height = r.height;
+        depth = r.depth;
+        colors = r.colors;
+        diminish_light = r.diminish_light;
+        make_shape();
+    }
+    return *this;
+}
+
+void Pyramid::make_shape()
+{
+    float translate_clip = TOL_SHIFT_SURFACE;
+
+    // shift rear surfaces into page to avoid z-fighting
+    // shift left surfaces left in x to avoid z-fighting
+    // shift right surfaces right in x to avoid z-fighting
+    // shift bottom surfaces down in y to avoid z-fighthing
+
+    Surface front(Point{center_x - width / 2, bottom_y, center_z + depth / 2, 1.0f},
+                  Point{center_x + width / 2, bottom_y, center_z + depth / 2, 1.0f},
+                  Point{center_x, bottom_y + height, center_z, 1.0f}, colors[0], diminish_light);
+    Surface rear(Point{center_x - width / 2, bottom_y, center_z - (translate_clip + depth / 2), 1.0f},
+                 Point{center_x + width / 2, bottom_y, center_z - (translate_clip + depth / 2), 1.0f},
+                 Point{center_x, bottom_y + height, (center_z - translate_clip), 1.0f}, colors[1], diminish_light);
+    Surface left(Point{center_x - (translate_clip + width / 2), bottom_y, center_z + depth / 2, 1.0f},
+                 Point{center_x - (translate_clip + width / 2), bottom_y, center_z - depth / 2, 1.0f},
+                 Point{center_x - translate_clip, bottom_y + height, center_z, 1.0f}, colors[2], diminish_light);
+    Surface right(Point{center_x + (translate_clip + width / 2), bottom_y, center_z + depth / 2, 1.0f},
+                  Point{center_x + (translate_clip + width / 2), bottom_y, center_z - depth / 2, 1.0f},
+                  Point{center_x + translate_clip, bottom_y + height, center_z, 1.0f}, colors[3], diminish_light);
+    Surface bottom_near(Point{center_x - width / 2, bottom_y - translate_clip, center_z + depth / 2, 1.0f},
+                        Point{center_x + width / 2, bottom_y - translate_clip, center_z + depth / 2, 1.0f},
+                        Point{center_x + width / 2, bottom_y - translate_clip, center_z - depth / 2, 1.0f}, colors[4], diminish_light);
+    Surface bottom_far(Point{center_x - width / 2, bottom_y - translate_clip, center_z + depth / 2, 1.0f},
+                       Point{center_x - width / 2, bottom_y - translate_clip, center_z - depth / 2, 1.0f},
+                       Point{center_x + width / 2, bottom_y - translate_clip, center_z - depth / 2, 1.0f}, colors[4], diminish_light);
+
+    surfaces.push_back(front);
+    surfaces.push_back(rear);
+    surfaces.push_back(left);
+    surfaces.push_back(right);
+    surfaces.push_back(bottom_near);
+    surfaces.push_back(bottom_far);
+}
+
+void Pyramid::translate(float dx, float dy, float dz)
+{
+    for (auto &surface : surfaces)
+    {
+        surface.translate(dx, dy, dz);
+    }
+}
+
+vector<Surface> &Pyramid::get_surfaces()
+{
+    return surfaces;
+}
+
+#endif

--- a/src/raster_engine.cpp
+++ b/src/raster_engine.cpp
@@ -4,6 +4,8 @@
 #include "surface.hpp"
 #include "renderer.hpp"
 #include "rectprism.hpp"
+#include "input.hpp"
+#include "map.hpp"
 
 using std::cout;
 
@@ -32,9 +34,11 @@ int main(int argc, char *argv[])
     bool quit = false;
     bool need_redraw = true;
 
-    RectPrism rect(1.5f, 1.5f, -5.0f, 2.0f, 2.0f, 2.0f);
+    // Initialize map and surfaces vector
+    Map map;
+    vector<Surface> all_surfaces;
 
-    Renderer engine(0.1f, 100.0f, 90.0f, WIDTH, HEIGHT);
+    Renderer engine(0.3f, 100.0f, 90.0f, WIDTH, HEIGHT);
     SDL_Event event;
 
     // Main game loop
@@ -53,54 +57,22 @@ int main(int argc, char *argv[])
             }
             else if (event.type == SDL_EVENT_KEY_DOWN)
             {
-                float translate_amount = 0.05f;
-                if (event.key.key == SDLK_A)
-                {
-                    rect.translate(-1 * translate_amount, 0.0f, 0.0f);
-                    need_redraw = true;
-                }
-                else if (event.key.key == SDLK_D)
-                {
-                    rect.translate(translate_amount, 0.0f, 0.0f);
-                    need_redraw = true;
-                }
-                else if (event.key.key == SDLK_W)
-                {
-                    rect.translate(0.0f, 0.0f, translate_amount);
-                    need_redraw = true;
-                }
-                else if (event.key.key == SDLK_S)
-                {
-                    rect.translate(0.0f, 0.0f, -1 * translate_amount);
-                    need_redraw = true;
-                }
-                else if (event.key.key == SDLK_Q)
-                {
-                    rect.translate(0.0f, translate_amount, 0.0f);
-                    need_redraw = true;
-                }
-                else if (event.key.key == SDLK_E)
-                {
-                    rect.translate(0.0f, -1 * translate_amount, 0.0f);
-                    need_redraw = true;
-                }
+                process_input(event, map.get_rect_prism(0), need_redraw);
             }
         }
 
-        // rect.translate(0.0f, 0.0f, 0.05f);
-        // need_redraw = true;
-
         if (need_redraw)
         {
-            // Black background
-            SDL_SetRenderDrawColor(renderer, BLACK.r, BLACK.g, BLACK.b, BLACK.a);
+            // Draw background
+            SDL_SetRenderDrawColor(renderer, BACK_COLOR.r, BACK_COLOR.g, BACK_COLOR.b, BACK_COLOR.a);
             // Clear screen
             SDL_RenderClear(renderer);
 
-            // vector<Surface> surfaces = {triangle_near, triangle_far};
+            // Get map surfaces
+            all_surfaces = map.get_map_surfaces();
+
             // Draw surfaces
-            engine.draw_surfaces(*renderer, rect.get_surfaces());
-            // engine.draw_surfaces(*renderer, surfaces);
+            engine.draw_surfaces(*renderer, all_surfaces);
 
             // Update the screen
             SDL_RenderPresent(renderer);

--- a/src/rect.hpp
+++ b/src/rect.hpp
@@ -1,0 +1,145 @@
+#ifndef RECT_HPP
+#define RECT_HPP
+
+#include <vector>
+#include <cstdlib>
+#include "point.h"
+#include "surface.hpp"
+#include "constants.h"
+
+using std::vector;
+
+// class defining a flat rectangle
+class Rect
+{
+private:
+    float center_x;
+    float center_y;
+    float center_z;
+    float width;
+    float height;
+    float depth;
+    Color color;
+    vector<Surface> surfaces;
+    bool diminish_light;
+
+public:
+    Rect(); // default constructor (initializes object to default state with no arguments)
+    Rect(const float &_x, const float &_y, const float &_z, const float &_w, const float &_h, const float &_d,
+         const Color &_color, const bool &_dim_light = false);
+    Rect(const Rect &);            // copy constructor
+    ~Rect();                       // destructor
+    Rect &operator=(const Rect &); // copy/assignment operator
+    void make_shape();
+    void translate(float dx, float dy, float dz);
+    vector<Surface> &get_surfaces();
+};
+
+// implementation
+Rect::Rect() : center_x(0), center_y(0), center_z(0), width(1), height(1), depth(1), color(GREEN), diminish_light(false) {}
+Rect::Rect(const float &_x, const float &_y, const float &_z, const float &_w, const float &_h, const float &_d,
+           const Color &_color, const bool &_dim_light)
+    : center_x(_x), center_y(_y), center_z(_z), width(_w), height(_h), depth(_d), color(_color), diminish_light(_dim_light)
+{
+    make_shape();
+}
+Rect::Rect(const Rect &r)
+{
+    center_x = r.center_x;
+    center_y = r.center_y;
+    center_z = r.center_z;
+    width = r.width;
+    height = r.height;
+    depth = r.depth;
+    color = r.color;
+    diminish_light = r.diminish_light;
+    make_shape();
+}
+
+Rect::~Rect() {}
+
+Rect &Rect::operator=(const Rect &r)
+{
+    if (this != &r)
+    {
+        center_x = r.center_x;
+        center_y = r.center_y;
+        center_z = r.center_z;
+        width = r.width;
+        height = r.height;
+        depth = r.depth;
+        color = r.color;
+        diminish_light = r.diminish_light;
+        make_shape();
+    }
+    return *this;
+}
+
+void Rect::make_shape()
+{
+    int false_count = 0;
+    vector<bool> bools = {width == 0.0f, height == 0.0f, depth == 0.0f};
+
+    for (auto b : bools)
+    {
+        if (b)
+        {
+            ++false_count;
+        }
+    }
+
+    if (false_count == 1)
+    {
+        Surface first_half;
+        Surface second_half;
+
+        // Flat rectangle aligned with depth-height plane
+        if (width == 0.0f)
+        {
+            first_half = Surface(Point{center_x, center_y - height / 2, center_z + depth / 2, 1.0f},
+                                 Point{center_x, center_y + height / 2, center_z + depth / 2, 1.0f},
+                                 Point{center_x, center_y - height / 2, center_z - depth / 2, 1.0f}, color, diminish_light);
+            second_half = Surface(Point{center_x, center_y + height / 2, center_z - depth / 2, 1.0f},
+                                  Point{center_x, center_y + height / 2, center_z + depth / 2, 1.0f},
+                                  Point{center_x, center_y - height / 2, center_z - depth / 2, 1.0f}, color, diminish_light);
+        }
+        // Flat rectangle aligned with width-depth plane
+        else if (height == 0.0f)
+        {
+            first_half = Surface(Point{center_x - width / 2, center_y, center_z + depth / 2, 1.0f},
+                                 Point{center_x + width / 2, center_y, center_z + depth / 2, 1.0f},
+                                 Point{center_x + width / 2, center_y, center_z - depth / 2, 1.0f}, color, diminish_light);
+            second_half = Surface(Point{center_x - width / 2, center_y, center_z + depth / 2, 1.0f},
+                                  Point{center_x - width / 2, center_y, center_z - depth / 2, 1.0f},
+                                  Point{center_x + width / 2, center_y, center_z - depth / 2, 1.0f}, color, diminish_light);
+        }
+        // Flat rectangle aligned with width-height plane
+        else if (depth == 0.0f)
+        {
+            first_half = Surface(Point{center_x - width / 2, center_y - height / 2, center_z, 1.0f},
+                                 Point{center_x + width / 2, center_y - height / 2, center_z, 1.0f},
+                                 Point{center_x + width / 2, center_y + height / 2, center_z, 1.0f}, color, diminish_light);
+            second_half = Surface(Point{center_x - width / 2, center_y - height / 2, center_z, 1.0f},
+                                  Point{center_x - width / 2, center_y + height / 2, center_z, 1.0f},
+                                  Point{center_x + width / 2, center_y + height / 2, center_z, 1.0f}, color, diminish_light);
+        }
+
+        surfaces.push_back(first_half);
+        surfaces.push_back(second_half);
+    }
+}
+
+void Rect::translate(float dx, float dy, float dz)
+{
+    for (auto &surface : surfaces)
+    {
+        surface.translate(dx, dy, dz);
+    }
+}
+
+vector<Surface> &Rect::get_surfaces()
+{
+    return surfaces;
+}
+
+#endif

--- a/src/surface.hpp
+++ b/src/surface.hpp
@@ -15,10 +15,11 @@ private:
     Point p1;
     Point p2;
     Color color;
+    bool diminish_light;
 
 public:
     Surface(); // default constructor (initializes object to default state with no arguments)
-    Surface(const Point &_p0, const Point &_p1, const Point &_p2, const Color &_color = RED);
+    Surface(const Point &_p0, const Point &_p1, const Point &_p2, const Color &_color = RED, const bool &_dim_light = false);
     Surface(const Surface &);            // copy constructor
     ~Surface();                          // destructor
     Surface &operator=(const Surface &); // copy/assignment operator
@@ -26,18 +27,20 @@ public:
     const Color get_color() const;
     void translate(float dx, float dy, float dz);
     vector<Point> get_points();
+    bool &get_diminish_light();
 };
 
 // implementation
 Surface::Surface() : p0({0.0f, 0.0f, 0.0f}), p1({0.0f, 0.0f, 0.0f}), p2({0.0f, 0.0f, 0.0f}) {}
-Surface::Surface(const Point &_p0, const Point &_p1, const Point &_p2, const Color &_color)
-    : p0(_p0), p1(_p1), p2(_p2), color(_color) {}
+Surface::Surface(const Point &_p0, const Point &_p1, const Point &_p2, const Color &_color, const bool &_dim_light)
+    : p0(_p0), p1(_p1), p2(_p2), color(_color), diminish_light(_dim_light) {}
 Surface::Surface(const Surface &s)
 {
     p0 = s.p0;
     p1 = s.p1;
     p2 = s.p2;
     color = s.color;
+    diminish_light = s.diminish_light;
 }
 
 Surface::~Surface() {}
@@ -50,6 +53,7 @@ Surface &Surface::operator=(const Surface &s)
         p1 = s.p1;
         p2 = s.p2;
         color = s.color;
+        diminish_light = s.diminish_light;
     }
     return *this;
 }
@@ -82,6 +86,11 @@ void Surface::translate(float dx, float dy, float dz)
 vector<Point> Surface::get_points()
 {
     return {p0, p1, p2};
+}
+
+bool &Surface::get_diminish_light()
+{
+    return diminish_light;
 }
 
 #endif


### PR DESCRIPTION
Created a Map class to store and organize the initialization of level data. Created supporting classes for two new shapes: a pyramid and a flat rectangle. These complement the rectangular prism class. The current map depicts a grass surface, two trees, a cloud, and blue sky (new default background color).

<img width="644" height="540" alt="10-06-25_1700" src="https://github.com/user-attachments/assets/86bdb687-5a77-4eef-b4e8-e906eb74f185" />
<br><br>

Refactored the input logic into a separate .hpp file, which currently still translates just one of the rectangular prisms. 

Performed rendering updates, including a reduced window size by default, and an increased tolerance for whether a pixel coordinate is within a triangle surface. Introduced offsets to pre-defined shapes to reduce z-fighting artifacts. 

Created an optional (per shape) diminished lighting feature, which decreases the brightness of the surface color as a function of z-depth from the camera. This is currently used on the grass surface.

